### PR TITLE
Create replit.nix and fixed an issue with replit

### DIFF
--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,6 @@
+{ pkgs }: {
+    deps = [
+        pkgs.firefox 
+        pkgs.cowsay
+    ];
+}


### PR DESCRIPTION
Fixed an issue with replit where it would throw an error instead of starting firefox 